### PR TITLE
Resolve Racon Conflict with Numeric Named Reads

### DIFF
--- a/src/rnabloom/olc/Layout.java
+++ b/src/rnabloom/olc/Layout.java
@@ -3405,7 +3405,7 @@ public class Layout {
             }
             else if (!containedSet.contains(name)) {
                 // this sequence either contains shorter sequences or it has no overlaps with others
-                fw.write(Long.toString(++seqID), nameSeq[1]);
+                fw.write("unitig" + Long.toString(++seqID), nameSeq[1]);
             }
         }
         fr.close();
@@ -3422,7 +3422,7 @@ public class Layout {
                     if (!visited.contains(name)) {
                         ArrayDeque<String> path = getUnambiguousExtension(seedVid);
 
-                        String header = Long.toString(++seqID);
+                        String header = "unitig" + Long.toString(++seqID);
                         if (path.size() > 1) {
                             header += " path=[" + String.join(",", path) + "]";
                         }
@@ -3442,7 +3442,7 @@ public class Layout {
             if (!visited.contains(name)) {
                 ArrayDeque<String> path = getUnambiguousExtension(seedVid);
                 
-                String header = Long.toString(++seqID);
+                String header = "unitig" + Long.toString(++seqID);
                 if (path.size() > 1) {
                     header += " path=[" + String.join(",", path) + "]";
                 }


### PR DESCRIPTION
This pull request addresses an open issue in Racon (https://github.com/isovic/racon/issues/233), where Racon encounters an error if reads and contigs have identical names. In our project, we have read files with numeric names generated by an upstream tool, leading to a naming conflict in Racon.

To resolve this, I have implemented a solution where a 'unitig' prefix is added to unitig fasta records. This change effectively prevents the name conflict in Racon, and subsequent tests confirm that RNA-Bloom now operates as expected. This update ensures compatibility and stability in RNA-Bloom, addressing the named issue without affecting other functionalities.